### PR TITLE
Update `bolt.Open` call with `options` parameter

### DIFF
--- a/cmd/boltd/main.go
+++ b/cmd/boltd/main.go
@@ -24,7 +24,7 @@ func main() {
 	}
 
 	// Open the database.
-	db, err := bolt.Open(path, 0600)
+	db, err := bolt.Open(path, 0600, nil)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
It is currently not possible to `go get` the package
because of backwards incompatible `github.com/boltdb/bolt`
API changes.

``` bash
$ go get github.com/boltdb/boltd/...
../../boltdb/boltd/cmd/boltd/main.go:27: not enough arguments in call to bolt.Open
```
