### PR TITLE
Supply required argument to bolt.Open()

### DIFF
--- a/cmd/boltd/main.go
+++ b/cmd/boltd/main.go
@@ -24,7 +24,7 @@ func main() {
 	}
 
 	// Open the database.
-	db, err := bolt.Open(path, 0600)
+	db, err := bolt.Open(path, 0600, nil)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
I assume API has changed and boltd seems to break for me unless the required argument is supplied
