### PR TITLE
Fix main.go - bolt.Open missing third argument.

### DIFF
--- a/cmd/boltd/main.go
+++ b/cmd/boltd/main.go
@@ -24,7 +24,7 @@ func main() {
 	}
 
 	// Open the database.
-	db, err := bolt.Open(path, 0600)
+	db, err := bolt.Open(path, 0600, nil)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
This fixes the error:

# github.com/boltdb/boltd/cmd/boltd
c:\...\Gocode\src\github.com\boltdb\boltd\cmd\boltd\main.go:27: not enough arguments in call to bolt.Open